### PR TITLE
Sprinkle annotation everywhere

### DIFF
--- a/globals.lua
+++ b/globals.lua
@@ -1,14 +1,17 @@
 -- Variables
 -- *********
+
+--TODO: write descriptions for the rest of the global variables
+---@class IB_Global
 Ib_global = {}
 
 -- Badge Vanilla?
-Ib_global.badge_vanilla                     = true
+Ib_global.badge_vanilla                     = true -- Set to false to disable the default badging of vanilla items
 
 -- Debug and Logging
-Ib_global.debug                             = false
-Ib_global.log_errors                        = true
-Ib_global.log_prefix                        = "Icon Badges Error: "
+Ib_global.debug                             = false -- Set to true to enable debug logging
+Ib_global.log_errors                        = true -- Set to false to silence error logging
+Ib_global.log_prefix                        = "Icon Badges Error: " -- What logs are prefixed with
 
 -- Graphical variables
 Ib_global.default_badge_shift_icon          = {-13, -13}
@@ -120,12 +123,12 @@ Ib_global.char_widths = {
 
 -- Settings variables
 if mods["galdocs-manufacturing"] then
-  Ib_global.activation                        = settings.startup["ib-activation"].value
+  Ib_global.activation                        = settings.startup["ib-activation"].value--[[@as boolean]]
 end
-Ib_global.ib_show_badges                    = settings.startup["ib-show-badges"].value
-Ib_global.ib_show_badges_scale              = settings.startup["ib-show-badges-scale"].value
-Ib_global.ib_badge_opacity                  = settings.startup["ib-badge-opacity"].value
-Ib_global.ib_zoom_visibility                = settings.startup["ib-zoom-visibility"].value
+Ib_global.ib_show_badges                    = settings.startup["ib-show-badges"].value--[[@as "Only GUI"|"Only Belts"|"All"]]
+Ib_global.ib_show_badges_scale              = settings.startup["ib-show-badges-scale"].value--[[@as "Tiny"|"Small"|"Average"|"Big"|"Why"]]
+Ib_global.ib_badge_opacity                  = settings.startup["ib-badge-opacity"].value--[[@as float]]
+Ib_global.ib_zoom_visibility                = settings.startup["ib-zoom-visibility"].value--[[@as "Far"|"Medium"|"Near"]]
 
 -- Parsing Badge Scale
 Ib_global.user_badge_scale_table = {

--- a/ib-lib.lua
+++ b/ib-lib.lua
@@ -297,6 +297,7 @@ end
 ---@param repeat_count int
 ---@param corner Badge.corners?
 function Build_letter_badge_pictures(picture, badge, invert, repeat_count, corner)
+  ---@cast picture data.SpriteSheet
   if not picture.layers then
     local newLayer = table.deepcopy(picture)
     picture.layers = {newLayer}
@@ -385,6 +386,7 @@ end
 ---@param corner Badge.corners?
 ---@param spacing double
 function Build_img_badge_pictures(picture, paths, size, scale, mips, repeat_count, corner, spacing)
+  ---@cast picture data.SpriteSheet
   if not picture.layers then
     local newLayer = table.deepcopy(picture)
     picture.layers = {newLayer}

--- a/ib-lib.lua
+++ b/ib-lib.lua
@@ -16,17 +16,24 @@
 ---| "right-bottom"
 ---| "left-top"
 ---| "right-top"
-local valid_corners = {
-  ["left-bottom"] = {1, -1},
-  ["right-bottom"] = {-1, -1},
-  ["left-top"] = {1, 1},
-  ["right-top"] = {-1, 1},
-}
 
 ---@param corner valid_badge_corners?
 ---@return {[1]:int,[2]:int} direction
 function Corner_to_direction(corner)
-  return valid_corners[corner] or {1,1}
+  local direction = {1, 1}
+  if corner == "left-bottom" then
+    direction = {1, -1}
+  end
+  if corner == "right-bottom" then
+    direction = {-1, -1}
+  end
+  if corner == "left-top" then
+    direction = {1, 1}
+  end
+  if corner == "right-top" then
+    direction = {-1, 1}
+  end
+  return direction
 end
 
 ---@param char string A single character string

--- a/ib-lib.lua
+++ b/ib-lib.lua
@@ -829,7 +829,6 @@ end
 -- Merge Badge List
 -- NOTE: To remove a badge from list1 (i.e. un-badging an item from vanilla), simply set the ib_data = {} for that entry
 -- WARNING: Using this function will overwrite entries in list1 with entries from list2!!!!
----comment
 ---@param list1 Badge.Badge_list
 ---@param list2 Badge.Badge_list
 ---@return Badge.Badge_list? merged_list

--- a/icon-badges.lua
+++ b/icon-badges.lua
@@ -1,3 +1,4 @@
+---@type Badge.Badge_list
 K2_badge_list = {}
 
 -- Item prototypes

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ Finally, use the function *Build_badge(prototype, ib_data)* to put your badge on
    The size of the image file.
 
 3. **ib_img_corner** :
-   *(optional)* Behaves perfectly analogously to ib_let_corner. While it can be different from the letter badge corner, there can be only one image badge corner, no matter how many images are referenced in ib_img_paths. Currently, the image badge will always be on top of the letter badge. If there's enough need, I can make this a setting.
+   *(optional)* Behaves perfectly analogously to ib_let_corner. While it can be different from the letter badge corner, there can be only one image badge corner, no matter how many images are referenced in ib_img_paths.
 
 4. **ib_img_mips** :
    *(optional)* The mip levels of the image. By default, it assumes none, but if the image has mipmaps in it, leaving this blank will cause a crash.

--- a/vanilla.lua
+++ b/vanilla.lua
@@ -4,6 +4,7 @@
 -- This is an example of how to structure badge data. Badge_list is a table of groups in data.raw (fluid, recipe, item, and 
 --   child-of-item prototypes) and each table pairs a prototype name with ib_data properties.
 
+---@type Badge.Badge_list
 Badge_list = {}
 
 -- Item prototypes


### PR DESCRIPTION
The important chunk is the `Badge.badge_data` and `Badge.Badge_list` definitions.
Those allow developers to get type annotation for the Badges if they unzip icon-badges and place it in their workspace.

Maybe it should get moved to a better location, just so it's directly easy to copy and paste. This 'better' location would also describe the signature of the exposed functions so they're not battling Undefined Global.

 I also updated the `readme.md` to no longer mention the possibility of an already-added option.